### PR TITLE
feat: 메인 페이지 마크업 UI을 구현하라

### DIFF
--- a/app/index.module.scss
+++ b/app/index.module.scss
@@ -1,0 +1,6 @@
+.selectedCardWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+  margin-bottom: 48px;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,20 @@
+import Button from 'components/common/Button';
 import LayoutContainer from 'components/common/LayoutContainer';
+import MostSelected from 'components/main/MostSelected';
+import TotalSelected from 'components/main/TotalSelected';
+
+import styles from './index.module.scss';
 
 function Page() {
   return (
-    <LayoutContainer backgroundColor="#EFC3BC">
-      test
+    <LayoutContainer backgroundColor="berrymilk">
+      <div className={styles.selectedCardWrapper}>
+        <MostSelected />
+        <TotalSelected />
+      </div>
+      <Button href="/sign-up" fullWidth>
+        go to sign up page
+      </Button>
     </LayoutContainer>
   );
 }

--- a/app/sign-up/layout.tsx
+++ b/app/sign-up/layout.tsx
@@ -3,7 +3,11 @@ import React from 'react';
 import LayoutContainer from 'components/common/LayoutContainer';
 
 function Layout({ children }: { children: React.ReactNode }) {
-  return <LayoutContainer backgroundColor="#606196">{children}</LayoutContainer>;
+  return (
+    <LayoutContainer backgroundColor="indigo">
+      {children}
+    </LayoutContainer>
+  );
 }
 
 export default Layout;

--- a/components/common/Label/Label.stories.tsx
+++ b/components/common/Label/Label.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<typeof Label> = {
   component: Label,
   tags: ['autodocs'],
   args: {
-    children: 'Label',
+    text: 'Label',
   },
 };
 

--- a/components/common/Label/index.module.scss
+++ b/components/common/Label/index.module.scss
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   padding: 0px 16px;
-  width: 135px;
+  width: fit-content;
   height: 40px;
   border-radius: 4px;
   border: 2px solid color("black");

--- a/components/common/Label/index.test.tsx
+++ b/components/common/Label/index.test.tsx
@@ -6,9 +6,7 @@ describe('Label', () => {
   const labelText = 'labelText';
 
   const renderLabel = () => render((
-    <Label>
-      {labelText}
-    </Label>
+    <Label text={labelText} />
   ));
 
   it('label이 나타나야만한다', () => {

--- a/components/common/Label/index.tsx
+++ b/components/common/Label/index.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { ReactNode } from 'react';
-
 import clsx from 'clsx';
 import { ColorType } from 'lib/types';
 
@@ -9,16 +7,16 @@ import styles from './index.module.scss';
 
 type Props = {
   color?: Exclude<ColorType, 'black'>;
-  children: ReactNode;
+  text: string;
 };
 
-function Label({ children, color = 'white' }: Props) {
+function Label({ text, color = 'white' }: Props) {
   return (
     <div className={clsx(styles.labelWrapper, {
       [styles[color]]: color,
     })}
     >
-      {children}
+      {text}
     </div>
   );
 }

--- a/components/common/LayoutContainer/index.module.scss
+++ b/components/common/LayoutContainer/index.module.scss
@@ -6,7 +6,7 @@
   max-width: 430px;
   min-height: calc(var(--vh, 1vh) * 100);
   position: relative;
-  color: #FFFFFF;
+  color: color("white");
   margin: 0 auto;
   padding: 24px;
 
@@ -42,4 +42,48 @@
       content: none;
     }
   }
+}
+
+.white {
+  background-color: color("white");
+}
+
+.lemon {
+  background-color: color("lemon");
+}
+
+.salmon {
+  background-color: color("salmon");
+}
+
+.mustard {
+  background-color: color("mustard");
+}
+
+.moss {
+  background-color: color("moss");
+}
+
+.berrymilk {
+  background-color: color("berrymilk");
+}
+
+.cloud {
+  background-color: color("cloud");
+}
+
+.indigo {
+  background-color: color("indigo");
+}
+
+.brick {
+  background-color: color("brick");
+}
+
+.forest {
+  background-color: color("forest");
+}
+
+.yam {
+  background-color: color("yam");
 }

--- a/components/common/LayoutContainer/index.tsx
+++ b/components/common/LayoutContainer/index.tsx
@@ -2,15 +2,20 @@
 
 import { PropsWithChildren } from 'react';
 
+import clsx from 'clsx';
+import { ColorType } from 'lib/types';
+
 import styles from './index.module.scss';
 
 type Props = {
-  backgroundColor: string;
+  backgroundColor: ColorType;
 };
 
 function LayoutContainer({ children, backgroundColor }: PropsWithChildren<Props>) {
   return (
-    <div className={styles.layoutContainer} style={{ backgroundColor }}>
+    <div
+      className={clsx(styles.layoutContainer, styles[backgroundColor])}
+    >
       {children}
     </div>
   );

--- a/components/main/LabelWithCards/index.module.scss
+++ b/components/main/LabelWithCards/index.module.scss
@@ -1,0 +1,16 @@
+.mainLayout {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 16px;
+
+  .cardWrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+  }
+}

--- a/components/main/LabelWithCards/index.tsx
+++ b/components/main/LabelWithCards/index.tsx
@@ -1,0 +1,22 @@
+import { PropsWithChildren } from 'react';
+
+import Label from 'components/common/Label';
+
+import styles from './index.module.scss';
+
+type Props = {
+  labelText: string;
+};
+
+function LabelWithCards({ labelText, children }: PropsWithChildren<Props>) {
+  return (
+    <div className={styles.mainLayout}>
+      <Label text={labelText} color="white" />
+      <div className={styles.cardWrapper}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default LabelWithCards;

--- a/components/main/MostSelected/index.tsx
+++ b/components/main/MostSelected/index.tsx
@@ -1,0 +1,16 @@
+import Card from 'components/common/Card';
+
+import LabelWithCards from '../LabelWithCards';
+
+function MostSelected() {
+  return (
+    <LabelWithCards labelText="제일 많이 선택된">
+      {/* TODO - 수정 */}
+      <Card color="indigo" icon="🧑‍💻" profile={null} type="default" title="1. GOAT 개발자" />
+      <Card color="cloud" icon="🏋️" profile={null} type="default" title="2. 갓생러" />
+      <Card color="yam" icon="🧐" profile={null} type="default" title="3. 이성적인 사람" />
+    </LabelWithCards>
+  );
+}
+
+export default MostSelected;

--- a/components/main/TotalSelected/index.tsx
+++ b/components/main/TotalSelected/index.tsx
@@ -1,0 +1,57 @@
+import Card from 'components/common/Card';
+
+import LabelWithCards from '../LabelWithCards';
+
+function TotalSelected() {
+  return (
+    <LabelWithCards labelText="전체">
+      {/* TODO - 수정 */}
+      <Card
+        color="indigo"
+        icon="🧑‍💻"
+        profile={{
+          company: 'picko',
+          position: '디자개발',
+          createdAt: '1분 전',
+        }}
+        type="avatar"
+        title="GOAT 개발자"
+      />
+      <Card
+        color="cloud"
+        icon="🏋️"
+        profile={{
+          company: 'picko',
+          position: '디자개발',
+          createdAt: '1분 전',
+        }}
+        type="avatar"
+        title="갓생러"
+      />
+      <Card
+        color="forest"
+        icon="🧐"
+        profile={{
+          company: 'picko',
+          position: '디자개발',
+          createdAt: '1분 전',
+        }}
+        type="avatar"
+        title="인내심이 강한 사람"
+      />
+      <Card
+        color="yam"
+        icon="🧐"
+        profile={{
+          company: 'picko',
+          position: '디자개발',
+          createdAt: '1분 전',
+        }}
+        type="avatar"
+        title="이성적인 사람"
+      />
+    </LabelWithCards>
+  );
+}
+
+export default TotalSelected;


### PR DESCRIPTION
- 메인 페이지 마크업 UI을 구현
- 디자인 UI만 구현
- Label 컴포넌트 수정

<img width="468" alt="image" src="https://github.com/for-earth/picko-frontend/assets/60910665/01f50060-9020-4a25-a472-de04586cac16">
